### PR TITLE
gitignore: rm apps/heatsuite/heatsuite.5sts.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,3 @@ _site
 Desktop.ini
 .sync_*.db*
 *.swp
-apps/heatsuite/heatsuite.5sts.js


### PR DESCRIPTION
Was added in a PR, but I want to keep gitignore here short.